### PR TITLE
Fix Exa API compatibility: remove deprecated use_autoprompt parameter

### DIFF
--- a/exa_router_search.py
+++ b/exa_router_search.py
@@ -974,7 +974,7 @@ class ToolsInternal:
             try:
                 exa = self._exa_client()
                 search_data = await asyncio.to_thread(
-                    exa.search, query, num_results=num_results, use_autoprompt=True
+                    exa.search, query, num_results=num_results
                 )
                 results = search_data.results
 


### PR DESCRIPTION
The use_autoprompt parameter was removed in exa-py v2.0.0 (released Oct 28, 2025). This was causing "unexpected keyword argument" errors during search operations.

Changes:
- Removed use_autoprompt=True from exa.search() call in _safe_exa_search method
- The autoprompt functionality may now be enabled by default in v2.0.0

Fixes the error: "Exa.search() got an unexpected keyword argument 'use_autoprompt'"